### PR TITLE
Builder refactor 2 2019

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,3 +4,4 @@ project(hoglsuite)
 set(CMAKE_CXX_STANDARD 11)
 
 add_subdirectory(src)
+add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.13)
+project(hoglsuite)
+
+set(CMAKE_CXX_STANDARD 11)
+
+add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,5 +3,7 @@ project(hoglsuite)
 
 set(CMAKE_CXX_STANDARD 11)
 
+add_compile_options(-O0 -Wall -g)
+
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/include/hogl/config-builder.hpp
+++ b/include/hogl/config-builder.hpp
@@ -41,9 +41,17 @@
 
 namespace hogl {
 
+    // fwd decl needed for config_builder_base accessors
     class output_builder;
     class format_builder;
+    class mask_builder;
 
+    /**
+     * @class config_builder_base just holds a reference to the actual config instance
+     * and provide:
+     * 1. accessors to all the builders - returning each by value
+     * 2. cast operator to the actual config
+     */
     class config_builder_base {
     public:
         explicit config_builder_base(config& cfg) : _config(cfg) {}
@@ -54,13 +62,10 @@ namespace hogl {
 
         // builder facets here
         output_builder output() const;
-
         format_builder format() const;
-
         mask_builder mask() const;
 
         /*
-        mask_builder mask() const;
         area_builder area() const;
         engine_options_builder engine_options() const;
         ringbuf_options_builder ringbuf_options() const;
@@ -71,22 +76,34 @@ namespace hogl {
         config& _config;
     };
 
+    /**
+     * @class config_builder is actually holding the config instance
+     * and since it is inheritting from base, once you have an instance
+     * of config_builder, you can access each builder individually and invoke functions
+     */
     class config_builder final : public config_builder_base {
     public:
-        explicit config_builder() : config_builder_base{_config} {}
+        explicit config_builder() : config_builder_base{_c} {}
     private:
         // can create it since config_builder is a friend of config
         // config's default ctor is private
-        config _config;
+        config _c;
     };
 
+    /**
+     * Individual builders
+     * each builder inherits from base and instantiate base with the config
+     * When we call config::create() we create a config_builder instance. It holds a config instance
+     * Now, when we chain calls like .output() or .format() (defined in base)
+     * then we create an instance of the builder and pass it a reference of the actual config instance
+     * this specific builder will work directly on the config instance. builders are friends in config class
+     */
     class output_builder final : public config_builder_base {
         using self = output_builder;
     public:
         explicit output_builder(config &cfg) : config_builder_base{cfg} {}
 
         self& stdout(uint32_t output_bufsize = 0) {
-
             _config._log_output.reset(new hogl::output_stdout(*_config._log_format,
                     _config.get_output_bufsize(output_bufsize)));
             return *this;
@@ -121,6 +138,25 @@ namespace hogl {
         self& basic(){
             _config._log_format.reset(new hogl::format_basic);
             return *this;
+        }
+    };
+
+    class mask_builder final : public config_builder_base {
+        using self = mask_builder;
+    public:
+        explicit mask_builder(config& cfg) : config_builder_base{cfg} {}
+
+        template <typename Arg, typename ... Args>
+        self& set(Arg mask, Args ... masks) {
+            print(mask);
+            this->set(masks...);
+            return *this;
+        }
+    private:
+        void set() {}
+        template <typename Arg>
+        void print(Arg mask) {
+            _config._mask << mask;
         }
     };
 

--- a/include/hogl/config-builder.hpp
+++ b/include/hogl/config-builder.hpp
@@ -1,0 +1,95 @@
+/*
+   Copyright (c) 2018, Max Krasnyansky <max.krasnyansky@gmail.com>
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without modification,
+   are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef PROJECT_CONFIG_BUILDER_HPP
+#define PROJECT_CONFIG_BUILDER_HPP
+
+#include <utility> // std::move
+
+#include "hogl/config.hpp"
+
+namespace hogl {
+
+    class output_builder;
+
+    class config_builder_base {
+    public:
+        explicit config_builder_base(config& cfg) : _config(cfg) {}
+
+        operator config() const {
+            return std::move(_config);
+        }
+
+        // builder facets here
+        output_builder output() const;
+        /*
+        format_builder format() const;
+        mask_builder mask() const;
+        area_builder area() const;
+        engine_options_builder engine_options() const;
+        ringbuf_options_builder ringbuf_options() const;
+         */
+    // protected so derived classes (specific builders)
+    // can access it when then need to call _config.xyz = something
+    protected:
+        config& _config;
+    };
+
+    class config_builder final : private config_builder_base {
+    public:
+        explicit config_builder() : config_builder_base{_config} {}
+    private:
+        // can create it since config_builder is a friend of config
+        // config's default ctor is private
+        config _config;
+    };
+
+    class output_builder final : public config_builder_base {
+        using self = output_builder;
+    public:
+        explicit output_builder(config &cfg) : config_builder_base{cfg} {}
+
+        self& stdout() {
+            _config._log_output = config::outputs::STDOUT;
+            return *this;
+        }
+        self& stderr() {
+            _config._log_output = config::outputs::STDERR;
+            return *this;
+        }
+        self& pipe() {
+            _config._log_output = config::outputs::PIPE;
+            return *this;
+        }
+        self& textfile() {
+            _config._log_output = config::outputs::TEXT_FILE;
+            return *this;
+        }
+    };
+
+} // ns hogl
+
+#endif //PROJECT_CONFIG_BUILDER_HPP

--- a/include/hogl/config-builder.hpp
+++ b/include/hogl/config-builder.hpp
@@ -57,6 +57,8 @@ namespace hogl {
 
         format_builder format() const;
 
+        mask_builder mask() const;
+
         /*
         mask_builder mask() const;
         area_builder area() const;
@@ -83,16 +85,6 @@ namespace hogl {
     public:
         explicit output_builder(config &cfg) : config_builder_base{cfg} {}
 
-        /*
-        if (log_output == "stderr")
-        lo = new hogl::output_stderr(*lf, output_bufsize);
-        else if (log_output == "stdout")
-        lo = new hogl::output_stdout(*lf, output_bufsize);
-        else if (log_output[0] == '|')
-        lo = new hogl::output_pipe(log_output.substr(1).c_str(), *lf, output_bufsize);
-        else
-        lo = new hogl::output_textfile(log_output.c_str(), *lf, output_bufsize);
-        */
         self& stdout(uint32_t output_bufsize = 0) {
 
             _config._log_output.reset(new hogl::output_stdout(*_config._log_format,

--- a/include/hogl/config-builder.hpp
+++ b/include/hogl/config-builder.hpp
@@ -34,6 +34,7 @@
 namespace hogl {
 
     class output_builder;
+    class format_builder;
 
     class config_builder_base {
     public:
@@ -45,8 +46,10 @@ namespace hogl {
 
         // builder facets here
         output_builder output() const;
-        /*
+
         format_builder format() const;
+
+        /*
         mask_builder mask() const;
         area_builder area() const;
         engine_options_builder engine_options() const;
@@ -86,6 +89,22 @@ namespace hogl {
         }
         self& textfile() {
             _config._log_output = config::outputs::TEXT_FILE;
+            return *this;
+        }
+    };
+
+    class format_builder final : public config_builder_base {
+        using self = format_builder;
+    public:
+        explicit format_builder(config& cfg) : config_builder_base{cfg} {}
+
+        self& raw(){
+            _config._log_format = config::formats::RAW;
+            return *this;
+        }
+
+        self& basic(){
+            _config._log_format = config::formats::RAW;
             return *this;
         }
     };

--- a/include/hogl/config.hpp
+++ b/include/hogl/config.hpp
@@ -43,8 +43,8 @@ namespace hogl {
         friend class config_builder;
         // all specific builders would directly access the below members
         friend class output_builder;
-        //
-        friend class config_builder;
+        friend class format_builder;
+
         // creation static function
         static config_builder create();
     private:
@@ -60,8 +60,8 @@ namespace hogl {
         };
         config() = default;
         static constexpr uint32_t    _output_bufsize = 10 * 1024 * 1024;
-        formats     _log_format;
-        outputs     _log_output;
+        formats     _log_format = formats::BASIC;
+        outputs     _log_output = outputs::STDOUT;
         hogl::ringbuf::options _ring_options;
         hogl::engine::options  _mask_options;
     };

--- a/include/hogl/config.hpp
+++ b/include/hogl/config.hpp
@@ -1,0 +1,68 @@
+/*
+   Copyright (c) 2018, Max Krasnyansky <max.krasnyansky@gmail.com>
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without modification,
+   are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef PROJECT_CONFIG_HPP
+#define PROJECT_CONFIG_HPP
+
+#include <string>
+
+#include "hogl/detail/ringbuf.hpp"
+#include "hogl/detail/engine.hpp"
+
+namespace hogl {
+
+    class config_builder;
+
+    class config final {
+    public:
+        // need this so config_builder can aggr/hold config instance
+        // so it needs access to private ctor
+        friend class config_builder;
+        // all specific builders would directly access the below members
+        friend class output_builder;
+        static config_builder create();
+    private:
+        enum struct formats : uint8_t {
+            RAW,
+            BASIC
+        };
+        enum struct outputs : uint8_t  {
+            STDOUT,
+            STDERR,
+            PIPE,
+            TEXT_FILE
+        };
+        config() = default;
+        uint32_t    _output_bufsize = 10 * 1024 * 1024
+        formats     _log_format;
+        outputs     _log_output;
+        hogl::ringbuf::options _ring_options;
+        hogl::engine::options  _mask_options;
+    };
+
+} // ns hogl
+
+#endif //PROJECT_CONFIG_HPP

--- a/include/hogl/config.hpp
+++ b/include/hogl/config.hpp
@@ -30,6 +30,7 @@
 #include <memory>
 #include <string>
 
+#include "hogl/detail/mask.hpp"
 #include "hogl/detail/ringbuf.hpp"
 #include "hogl/detail/engine.hpp"
 
@@ -51,6 +52,8 @@ namespace hogl {
 
         // creation static function
         static config_builder create();
+
+        hogl::mask mask() const { return _mask; }
     private:
         config() = default;
 
@@ -59,11 +62,12 @@ namespace hogl {
         }
 
         static constexpr uint32_t     _output_bufsize = 10 * 1024 * 1024;
-        std::unique_ptr<hogl::format> _log_format;
-        std::unique_ptr<hogl::output> _log_output;
-        hogl::mask                    _mask;
-        hogl::ringbuf::options        _ring_options;
-        hogl::engine::options         _engine_options;
+        // FIXME TODO need defaults here
+        std::unique_ptr<format> _log_format;
+        std::unique_ptr<output> _log_output;
+        hogl::mask              _mask;
+        ringbuf::options        _ring_options;
+        engine::options         _engine_options;
     };
 
 } // ns hogl

--- a/include/hogl/config.hpp
+++ b/include/hogl/config.hpp
@@ -45,6 +45,7 @@ namespace hogl {
         // all specific builders would directly access the below members
         friend class output_builder;
         friend class format_builder;
+        friend class mask_builder;
         friend class ringbuf_builder;
         friend class engine_builder;
 
@@ -60,6 +61,7 @@ namespace hogl {
         static constexpr uint32_t     _output_bufsize = 10 * 1024 * 1024;
         std::unique_ptr<hogl::format> _log_format;
         std::unique_ptr<hogl::output> _log_output;
+        hogl::mask                    _mask;
         hogl::ringbuf::options        _ring_options;
         hogl::engine::options         _engine_options;
     };

--- a/include/hogl/config.hpp
+++ b/include/hogl/config.hpp
@@ -56,7 +56,7 @@ namespace hogl {
             TEXT_FILE
         };
         config() = default;
-        uint32_t    _output_bufsize = 10 * 1024 * 1024
+        static constexpr uint32_t    _output_bufsize = 10 * 1024 * 1024;
         formats     _log_format;
         outputs     _log_output;
         hogl::ringbuf::options _ring_options;

--- a/include/hogl/config.hpp
+++ b/include/hogl/config.hpp
@@ -43,6 +43,9 @@ namespace hogl {
         friend class config_builder;
         // all specific builders would directly access the below members
         friend class output_builder;
+        //
+        friend class config_builder;
+        // creation static function
         static config_builder create();
     private:
         enum struct formats : uint8_t {

--- a/include/hogl/config.hpp
+++ b/include/hogl/config.hpp
@@ -27,6 +27,7 @@
 #ifndef PROJECT_CONFIG_HPP
 #define PROJECT_CONFIG_HPP
 
+#include <memory>
 #include <string>
 
 #include "hogl/detail/ringbuf.hpp"
@@ -44,26 +45,23 @@ namespace hogl {
         // all specific builders would directly access the below members
         friend class output_builder;
         friend class format_builder;
+        friend class ringbuf_builder;
+        friend class engine_builder;
 
         // creation static function
         static config_builder create();
     private:
-        enum struct formats : uint8_t {
-            RAW,
-            BASIC
-        };
-        enum struct outputs : uint8_t  {
-            STDOUT,
-            STDERR,
-            PIPE,
-            TEXT_FILE
-        };
         config() = default;
-        static constexpr uint32_t    _output_bufsize = 10 * 1024 * 1024;
-        formats     _log_format = formats::BASIC;
-        outputs     _log_output = outputs::STDOUT;
-        hogl::ringbuf::options _ring_options;
-        hogl::engine::options  _mask_options;
+
+        uint32_t get_output_bufsize(const uint32_t output_bufsize) const noexcept {
+                return output_bufsize ? output_bufsize : _output_bufsize;
+        }
+
+        static constexpr uint32_t     _output_bufsize = 10 * 1024 * 1024;
+        std::unique_ptr<hogl::format> _log_format;
+        std::unique_ptr<hogl::output> _log_output;
+        hogl::ringbuf::options        _ring_options;
+        hogl::engine::options         _engine_options;
     };
 
 } // ns hogl

--- a/include/hogl/config.hpp
+++ b/include/hogl/config.hpp
@@ -33,6 +33,11 @@
 #include "hogl/detail/mask.hpp"
 #include "hogl/detail/ringbuf.hpp"
 #include "hogl/detail/engine.hpp"
+#include "hogl/engine.hpp"
+#include "hogl/mask.hpp"
+
+#include "hogl/format-basic.hpp"
+#include "hogl/output-stderr.hpp"
 
 namespace hogl {
 
@@ -53,9 +58,17 @@ namespace hogl {
         // creation static function
         static config_builder create();
 
+        void activate() { hogl::activate(*_log_output);}
+        void apply_mask() { hogl::apply_mask(_mask); }
         hogl::mask mask() const { return _mask; }
     private:
-        config() = default;
+        static constexpr auto FAST = "fast1";
+        // log_format/output can be created once per config
+        // otherwise when trying to change the underlying format and then the output
+        // the reference "&_format" in output class would dangle
+        config() : _ring_options{ringbuf::default_options},
+        _engine_options{engine::default_options}
+        {}
 
         uint32_t get_output_bufsize(const uint32_t output_bufsize) const noexcept {
                 return output_bufsize ? output_bufsize : _output_bufsize;

--- a/include/hogl/detail/format.hpp
+++ b/include/hogl/detail/format.hpp
@@ -66,16 +66,16 @@ public:
 	 * @param n name of the current output (filename, pipe, etc)
 	 * @param first true if this is the first header (first file chunk)
 	 */
-	virtual void header(ostrbuf &s, const char *n, bool first) {};
+	virtual void header(ostrbuf &s, const char *n, bool first) {}
 
 	/**
 	 * Generate format footer.
 	 * @param s reference to the string buffer
 	 * @param n name of the next output (filename, pipe, etc), set to zero for the last chunk.
 	 */
-	virtual void footer(ostrbuf &s, const char *n) {};
+	virtual void footer(ostrbuf &s, const char *n) {}
 
-	virtual ~format() {}
+	virtual ~format() = default;
 };
 
 } // namespace hogl

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,63 @@
+# Copyright (c) 2015, Max Krasnyansky <max.krasnyansky@gmail.com>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+set(LIB_NAME hogl)
+project(${LIB_NAME})
+
+set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+
+include_directories(${INCLUDE_DIR})
+
+set(SRC_FILES
+        area.cc
+        c-api.cc
+        defring.cc
+        deftimesource.cc
+        engine.cc
+        flush.cc
+        format-basic.cc
+        format-raw.cc
+        internal.cc
+#        mask-boost.cc FIXME this depends on CXX11
+        mask.cc
+        ostrbuf-fd.cc
+        ostrbuf-stdio.cc
+        ostrbuf.cc
+        output-file.cc
+        output-pipe.cc
+        output-stderr.cc
+        output-stdout.cc
+        output-textfile.cc
+        output.cc
+        platform.cc
+        post.cc
+        ringbuf.cc
+        timesource.cc
+        tls.cc)
+
+set(HOGL_STATIC_LIB ${LIB_NAME}Static)
+set(HOGL_DYNAMIC_LIB ${LIB_NAME})
+add_library(${HOGL_STATIC_LIB} STATIC ${SRC_FILES})
+add_library(${HOGL_DYNAMIC_LIB} SHARED ${SRC_FILES} ../include/hogl/config.hpp config.cc ../include/hogl/config-builder.hpp config-builders.cc)
+install(TARGETS ${LIB_NAME} DESTINATION lib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,9 +25,7 @@
 set(LIB_NAME hogl)
 project(${LIB_NAME})
 
-set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-
-include_directories(${INCLUDE_DIR})
+set(INCLUDE_DIR ${hoglsuite_SOURCE_DIR}/include)
 
 set(SRC_FILES
         area.cc
@@ -41,7 +39,6 @@ set(SRC_FILES
         format-basic.cc
         format-raw.cc
         internal.cc
-#        mask-boost.cc FIXME this depends on CXX11
         mask.cc
         ostrbuf-fd.cc
         ostrbuf-stdio.cc
@@ -62,4 +59,8 @@ set(HOGL_STATIC_LIB ${LIB_NAME}Static)
 set(HOGL_DYNAMIC_LIB ${LIB_NAME})
 add_library(${HOGL_STATIC_LIB} STATIC ${SRC_FILES})
 add_library(${HOGL_DYNAMIC_LIB} SHARED ${SRC_FILES})
+
+target_include_directories(${HOGL_STATIC_LIB}  PUBLIC ${INCLUDE_DIR})
+target_include_directories(${HOGL_DYNAMIC_LIB} PUBLIC ${INCLUDE_DIR})
+
 install(TARGETS ${LIB_NAME} DESTINATION lib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,8 @@ include_directories(${INCLUDE_DIR})
 set(SRC_FILES
         area.cc
         c-api.cc
+        config.cc
+        config-builders.cc
         defring.cc
         deftimesource.cc
         engine.cc
@@ -59,5 +61,5 @@ set(SRC_FILES
 set(HOGL_STATIC_LIB ${LIB_NAME}Static)
 set(HOGL_DYNAMIC_LIB ${LIB_NAME})
 add_library(${HOGL_STATIC_LIB} STATIC ${SRC_FILES})
-add_library(${HOGL_DYNAMIC_LIB} SHARED ${SRC_FILES} ../include/hogl/config.hpp config.cc ../include/hogl/config-builder.hpp config-builders.cc)
+add_library(${HOGL_DYNAMIC_LIB} SHARED ${SRC_FILES})
 install(TARGETS ${LIB_NAME} DESTINATION lib)

--- a/src/config-builders.cc
+++ b/src/config-builders.cc
@@ -32,13 +32,16 @@ namespace hogl {
         return output_builder{_config};
     }
 
-
     format_builder config_builder_base::format() const {
         return format_builder{_config};
     }
 
     mask_builder config_builder_base::mask() const {
         return mask_builder{_config};
+    }
+
+    area_builder config_builder_base::area() const {
+        return area_builder{_config};
     }
 
 } // ns hogl

--- a/src/config-builders.cc
+++ b/src/config-builders.cc
@@ -1,0 +1,35 @@
+/*
+   Copyright (c) 2018, Max Krasnyansky <max.krasnyansky@gmail.com>
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without modification,
+   are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "hogl/config-builder.hpp"
+
+namespace hogl {
+
+    output_builder config_builder_base::output() const {
+        return output_builder{_config};
+    }
+
+} // ns hogl

--- a/src/config-builders.cc
+++ b/src/config-builders.cc
@@ -37,4 +37,8 @@ namespace hogl {
         return format_builder{_config};
     }
 
+    mask_builder config_builder_base::mask() const {
+        return mask_builder{_config};
+    }
+
 } // ns hogl

--- a/src/config-builders.cc
+++ b/src/config-builders.cc
@@ -32,4 +32,9 @@ namespace hogl {
         return output_builder{_config};
     }
 
+
+    format_builder config_builder_base::format() const {
+        return format_builder{_config};
+    }
+
 } // ns hogl

--- a/src/config.cc
+++ b/src/config.cc
@@ -1,0 +1,36 @@
+/*
+   Copyright (c) 2018, Max Krasnyansky <max.krasnyansky@gmail.com>
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without modification,
+   are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "hogl/config.hpp"
+#include "hogl/config-builder.hpp"
+
+namespace hogl {
+
+    config_builder config::create() {
+        return config_builder{};
+    }
+
+} // ns hogl

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,14 @@
+project(tests)
+
+add_executable(builder-test
+        builder_test.cc
+)
+
+target_include_directories(builder-test
+        PRIVATE
+        ${hoglStatic}
+)
+
+target_link_libraries(builder-test
+    hogl
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,5 +10,7 @@ target_include_directories(builder-test
 )
 
 target_link_libraries(builder-test
-    hogl
+        hogl
+        ffi
+        pthread
 )

--- a/tests/builder_test.cc
+++ b/tests/builder_test.cc
@@ -34,11 +34,12 @@ int main(int argc, char *argv[])
     std::string log_format("fast1");
     constexpr unsigned int output_bufsize = 10 * 1024 * 1024;
 
-    auto config = hogl::config::create()
+    hogl::config config = hogl::config::create()
             .format().basic()
             .output().stdout()
-            .mask(".*");
+            .mask().set(".*", "DEBUG:.*");
 
+    std::clog << config.mask() << std::endl;
 
 /*
     hogl::mask logmask(".*", 0);

--- a/tests/builder_test.cc
+++ b/tests/builder_test.cc
@@ -34,7 +34,10 @@ int main(int argc, char *argv[])
     std::string log_format("fast1");
     constexpr unsigned int output_bufsize = 10 * 1024 * 1024;
 
-    //hogl::config_builder builder;
+    auto config = hogl::config::create()
+            .format().basic()
+            .output().stdout();
+
 
 /*
     hogl::format *lf;

--- a/tests/builder_test.cc
+++ b/tests/builder_test.cc
@@ -26,51 +26,55 @@
 
 #include <memory>
 
+#include "hogl/post.hpp"
+
 #include "hogl/config-builder.hpp"
+
+enum test_sect_id {
+    TEST_DEBUG,
+    TEST_INFO,
+    TEST_WARN,
+    TEST_ERROR,
+    TEST_EXTRA_DEBUG,
+    TEST_EXTRA_INFO,
+    TEST_TRACE,
+    TEST_HEXDUMP,
+};
+
+static const char *test_sect_names[] = {
+        "DEBUG",
+        "INFO",
+        "WARN",
+        "ERROR",
+        "EXTRA:DEBUG",
+        "EXTRA:INFO",
+        "TRACE",
+        "HEXDUMP",
+        0,
+};
 
 int main(int argc, char *argv[])
 {
     std::string log_output("stdout");
     std::string log_format("fast1");
     constexpr unsigned int output_bufsize = 10 * 1024 * 1024;
+    hogl::area *test_area = nullptr;
 
     hogl::config config = hogl::config::create()
             .format().basic()
             .output().stdout()
-            .mask().set(".*", "DEBUG:.*");
+            .mask().set(".*", "DEBUG:.*")
+            .activate()
+            .area().add(test_area, "TEST-AREA", test_sect_names);
 
     std::clog << config.mask() << std::endl;
+    config.apply_mask();
+    assert(test_area);
 
-/*
-    hogl::mask logmask(".*", 0);
-
-    hogl::activate(*lo);
-
-    test_area = hogl::add_area("TEST-AREA", test_sect_names);
-
-    // Test double add (with reuse)
-    test_area = hogl::add_area("TEST-AREA", test_sect_names);
-
-    // Test double add (failed)
-    const char *a0_sections[] = { "X", 0 };
-    const hogl::area *a0 = hogl::add_area("TEST-AREA", a0_sections);
-    assert(a0 == 0);
-
-    hogl::apply_mask(logmask);
-
-    printf("sizeof(hogl::record)  = %lu\n", (unsigned long) sizeof(hogl::record));
-    printf("sizeof(hogl::ringbuf) = %lu\n", (unsigned long) sizeof(hogl::ringbuf));
-
-    fflush(stdout);
-    fflush(stderr);
-
-    std::cerr << *hogl::default_engine;
+    hogl::post(test_area, TEST_INFO, "some string\n%s", "hello world");
 
     hogl::deactivate();
 
-    delete lo;
-    delete lf;
-*/
     printf("Passed\n");
     return 0;
 }

--- a/tests/builder_test.cc
+++ b/tests/builder_test.cc
@@ -1,0 +1,4 @@
+//
+// Created by kobi on 2/12/19.
+//
+

--- a/tests/builder_test.cc
+++ b/tests/builder_test.cc
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
             .format().basic()
             .output().stdout()
             .mask().set(".*", "DEBUG:.*")
-            .activate()
+            .activate() // activate is needed before calling add area
             .area().add(test_area, "TEST-AREA", test_sect_names);
 
     std::clog << config.mask() << std::endl;

--- a/tests/builder_test.cc
+++ b/tests/builder_test.cc
@@ -1,4 +1,88 @@
-//
-// Created by kobi on 2/12/19.
-//
+/*
+   Copyright (c) 2019, Max Krasnyansky <max.krasnyansky@gmail.com>
+   All rights reserved.
 
+   Redistribution and use in source and binary forms, with or without modification,
+   are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <memory>
+
+#include "hogl/config-builder.hpp"
+
+int main(int argc, char *argv[])
+{
+    std::string log_output("stdout");
+    std::string log_format("fast1");
+    constexpr unsigned int output_bufsize = 10 * 1024 * 1024;
+
+    //hogl::config_builder builder;
+
+/*
+    hogl::format *lf;
+    hogl::output *lo;
+
+    if (log_format == "raw")
+        lf = new hogl::format_raw();
+    else
+        lf = new hogl::format_basic(log_format.c_str());
+
+    if (log_output == "stderr")
+        lo = new hogl::output_stderr(*lf, output_bufsize);
+    else if (log_output == "stdout")
+        lo = new hogl::output_stdout(*lf, output_bufsize);
+    else if (log_output[0] == '|')
+        lo = new hogl::output_pipe(log_output.substr(1).c_str(), *lf, output_bufsize);
+    else
+        lo = new hogl::output_textfile(log_output.c_str(), *lf, output_bufsize);
+
+    hogl::mask logmask(".*", 0);
+
+    hogl::activate(*lo);
+
+    test_area = hogl::add_area("TEST-AREA", test_sect_names);
+
+    // Test double add (with reuse)
+    test_area = hogl::add_area("TEST-AREA", test_sect_names);
+
+    // Test double add (failed)
+    const char *a0_sections[] = { "X", 0 };
+    const hogl::area *a0 = hogl::add_area("TEST-AREA", a0_sections);
+    assert(a0 == 0);
+
+    hogl::apply_mask(logmask);
+
+    printf("sizeof(hogl::record)  = %lu\n", (unsigned long) sizeof(hogl::record));
+    printf("sizeof(hogl::ringbuf) = %lu\n", (unsigned long) sizeof(hogl::ringbuf));
+
+    fflush(stdout);
+    fflush(stderr);
+
+    std::cerr << *hogl::default_engine;
+
+    hogl::deactivate();
+
+    delete lo;
+    delete lf;
+*/
+    printf("Passed\n");
+    return 0;
+}

--- a/tests/builder_test.cc
+++ b/tests/builder_test.cc
@@ -36,27 +36,11 @@ int main(int argc, char *argv[])
 
     auto config = hogl::config::create()
             .format().basic()
-            .output().stdout();
+            .output().stdout()
+            .mask(".*");
 
 
 /*
-    hogl::format *lf;
-    hogl::output *lo;
-
-    if (log_format == "raw")
-        lf = new hogl::format_raw();
-    else
-        lf = new hogl::format_basic(log_format.c_str());
-
-    if (log_output == "stderr")
-        lo = new hogl::output_stderr(*lf, output_bufsize);
-    else if (log_output == "stdout")
-        lo = new hogl::output_stdout(*lf, output_bufsize);
-    else if (log_output[0] == '|')
-        lo = new hogl::output_pipe(log_output.substr(1).c_str(), *lf, output_bufsize);
-    else
-        lo = new hogl::output_textfile(log_output.c_str(), *lf, output_bufsize);
-
     hogl::mask logmask(".*", 0);
 
     hogl::activate(*lo);


### PR DESCRIPTION
Do not merge :)
just take a look at this idea and see if you think it worth continuing working on.
I thought of hiding the init part in a builder to make it more "user friendly".
There is still lots of work here but before I continue, I wanted to see if this is something that looks helpful.
take a look at the new builder test file and the config/config builder hpp/cc.

you can ignore the cmake (though I wanted to have a cmake support for hogl as well sometime in the future). I needed cmake to be able to work with my tools.